### PR TITLE
Add Drupal Chat module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# drupalChat
+# Drupal Chat Module
+
+This repository provides a minimal Drupal module that renders a simple chat interface. The chat communicates with a microservice using HTTP requests.
+
+## Installation
+
+1. Copy the `drupal_chat` directory into your Drupal project's `modules` folder.
+2. Enable the **Drupal Chat** module from the Drupal administration interface.
+3. Place the "Drupal Chat" block in a region of your theme.
+
+## Configuration
+
+The module uses the microservice located at:
+
+```
+http://eintelligent-003-site16.qtempurl.com/api/drupal-ai/ask
+```
+
+No additional configuration is required.
+
+## Usage
+
+Enter a question in the chat input and press **Enviar**. The module will send the text to the microservice and display the response inside the chat window.
+
+The interface is styled with a small CSS file that exposes the following color variables:
+
+```
+:root {
+  --color-primario: #004a93;
+  --color-secundario: #00a0e8;
+  --color-fondo: #ffffff;
+  --color-texto: #333333;
+  --color-texto-secundario: #666666;
+  --color-borde: #dddddd;
+}
+```
+
+Feel free to adjust these colors to match your theme.

--- a/drupal_chat/css/chat.css
+++ b/drupal_chat/css/chat.css
@@ -1,0 +1,64 @@
+:root {
+  --color-primario: #004a93;
+  --color-secundario: #00a0e8;
+  --color-fondo: #ffffff;
+  --color-texto: #333333;
+  --color-texto-secundario: #666666;
+  --color-borde: #dddddd;
+}
+
+.drupal-chat {
+  border: 1px solid var(--color-borde);
+  background: var(--color-fondo);
+  font-family: Arial, sans-serif;
+  max-width: 400px;
+}
+
+.drupal-chat .chat-window {
+  height: 300px;
+  overflow-y: auto;
+  padding: 1em;
+  border-bottom: 1px solid var(--color-borde);
+}
+
+.drupal-chat .chat-message {
+  margin-bottom: 0.5em;
+}
+
+.drupal-chat .chat-message.user {
+  text-align: right;
+  color: var(--color-primario);
+}
+
+.drupal-chat .chat-message.assistant {
+  text-align: left;
+  color: var(--color-texto-secundario);
+}
+
+.drupal-chat .chat-message.error {
+  color: red;
+}
+
+.drupal-chat .chat-input {
+  display: flex;
+  padding: 0.5em;
+}
+
+.drupal-chat .chat-question {
+  flex-grow: 1;
+  padding: 0.5em;
+  border: 1px solid var(--color-borde);
+}
+
+.drupal-chat .chat-send {
+  background: var(--color-primario);
+  border: none;
+  color: #fff;
+  padding: 0.5em 1em;
+  margin-left: 0.5em;
+  cursor: pointer;
+}
+
+.drupal-chat .chat-send:hover {
+  background: var(--color-secundario);
+}

--- a/drupal_chat/drupal_chat.info.yml
+++ b/drupal_chat/drupal_chat.info.yml
@@ -1,0 +1,5 @@
+name: 'Drupal Chat'
+type: module
+description: 'Simple chat interface that consumes a microservice.'
+package: Custom
+core_version_requirement: '^9 || ^10'

--- a/drupal_chat/drupal_chat.libraries.yml
+++ b/drupal_chat/drupal_chat.libraries.yml
@@ -1,0 +1,10 @@
+chat:
+  css:
+    theme:
+      css/chat.css: {}
+  js:
+    js/chat.js: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings
+    - core/once

--- a/drupal_chat/drupal_chat.module
+++ b/drupal_chat/drupal_chat.module
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Implements hook_theme().
+ */
+function drupal_chat_theme($existing, $type, $theme, $path) {
+  return [
+    'drupal_chat_block' => [
+      'variables' => [],
+      'template' => 'drupal-chat-block',
+    ],
+  ];
+}

--- a/drupal_chat/js/chat.js
+++ b/drupal_chat/js/chat.js
@@ -34,7 +34,7 @@
               }
             })
             .catch((err) => {
-              appendMessage('Error: ' + err.message, 'error');
+              appendMessage(Drupal.t('Error: ') + err.message, 'error');
             });
         }
 

--- a/drupal_chat/js/chat.js
+++ b/drupal_chat/js/chat.js
@@ -1,0 +1,51 @@
+(function (Drupal, drupalSettings, once) {
+  Drupal.behaviors.drupalChat = {
+    attach(context) {
+      once('drupal-chat', '.drupal-chat', context).forEach((chat) => {
+        const endpoint = drupalSettings.drupal_chat.endpoint;
+        const chatWindow = chat.querySelector('.chat-window');
+        const input = chat.querySelector('.chat-question');
+        const button = chat.querySelector('.chat-send');
+
+        function appendMessage(text, sender) {
+          const div = document.createElement('div');
+          div.className = 'chat-message ' + sender;
+          div.textContent = text;
+          chatWindow.appendChild(div);
+          chatWindow.scrollTop = chatWindow.scrollHeight;
+        }
+
+        function sendMessage() {
+          const question = input.value.trim();
+          if (!question) {
+            return;
+          }
+          appendMessage(question, 'user');
+          input.value = '';
+          fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ question: question, temperature: 0.2, max_tokens: 100 }),
+          })
+            .then((response) => response.json())
+            .then((data) => {
+              if (data.answer) {
+                appendMessage(data.answer, 'assistant');
+              }
+            })
+            .catch((err) => {
+              appendMessage('Error: ' + err.message, 'error');
+            });
+        }
+
+        button.addEventListener('click', sendMessage);
+        input.addEventListener('keypress', function (e) {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            sendMessage();
+          }
+        });
+      });
+    },
+  };
+})(Drupal, drupalSettings, once);

--- a/drupal_chat/src/Plugin/Block/DrupalChatBlock.php
+++ b/drupal_chat/src/Plugin/Block/DrupalChatBlock.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\drupal_chat\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a Drupal Chat block.
+ *
+ * @Block(
+ *   id = "drupal_chat_block",
+ *   admin_label = @Translation("Drupal Chat")
+ * )
+ */
+class DrupalChatBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return [
+      '#theme' => 'drupal_chat_block',
+      '#attached' => [
+        'library' => [
+          'drupal_chat/chat',
+        ],
+        'drupalSettings' => [
+          'drupal_chat' => [
+            'endpoint' => 'http://eintelligent-003-site16.qtempurl.com/api/drupal-ai/ask',
+          ],
+        ],
+      ],
+    ];
+  }
+
+}

--- a/drupal_chat/templates/drupal-chat-block.html.twig
+++ b/drupal_chat/templates/drupal-chat-block.html.twig
@@ -1,0 +1,7 @@
+<div class="drupal-chat">
+  <div class="chat-window"></div>
+  <div class="chat-input">
+    <input type="text" class="chat-question" placeholder="{{ 'Escribe tu pregunta...'|t }}" />
+    <button class="chat-send">{{ 'Enviar'|t }}</button>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- clean up README and provide instructions
- add `drupal_chat` module with block plugin, template, JS, and CSS

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661f334c208329a580f1091a0c6904